### PR TITLE
Fix `nomad agent-info command` in docs/nomad.md

### DIFF
--- a/docs/nomad.md
+++ b/docs/nomad.md
@@ -29,7 +29,7 @@ hashi-up nomad install \
 When the command finishes, try to access Nomad using the UI at http://192.168.100:4646 or with the cli:
 
 ```sh
-nomad agent-info -address==http://192.168.0.100:4646
+nomad agent-info -address=http://192.168.0.100:4646
 ```
 
 ### Join some agents to your Nomad server


### PR DESCRIPTION
Fixes this error:
```
Error initializing client: invalid address '=http://10.0.0.12:4646': parse =http://10.0.0.12:4646: first path segment in URL cannot contain colon
```

It may be a quirk with my specific version so feel free to close if so.
(Nomad v0.9.0 on a mac)