### PR TITLE
Fix vault cluster addr

### DIFF
--- a/pkg/config/vault.go
+++ b/pkg/config/vault.go
@@ -61,7 +61,7 @@ func (c VaultConfig) GenerateConfigFile() string {
 	}
 
 	if len(c.ClusterAddr) != 0 {
-		rootBody.SetAttributeValue("cluster_addr", cty.StringVal(c.ConsulAddr))
+		rootBody.SetAttributeValue("cluster_addr", cty.StringVal(c.ClusterAddr))
 	}
 
 	for _, a := range c.Address {


### PR DESCRIPTION
When specifying the `--cluster-addr`, the `c.ConsulAddr` value was taken. This fixes this issue