### PR TITLE
update suffix for "arm*" architecture

### DIFF
--- a/scripts/install_consul.sh
+++ b/scripts/install_consul.sh
@@ -55,7 +55,7 @@ setup_verify_arch() {
     SUFFIX=arm64
     ;;
   arm*)
-    SUFFIX=armhfv6
+    SUFFIX=arm
     ;;
   *)
     fatal "Unsupported architecture $ARCH"


### PR DESCRIPTION
Update the suffix of `arm*` architecture in `scripts/install_consul.sh`

The current suffix being set (`armhfv6`) does not correspond with hashicorp's release files.

Current generated URL returns `403 forbidden`:
https://releases.hashicorp.com/consul/1.11.2/consul_1.11.2_linux_armhfv6.zip

Updated generated URL returns `200 OK`
https://releases.hashicorp.com/consul/1.11.2/consul_1.11.2_linux_arm.zip